### PR TITLE
Vymenene export tlacitko za print tlacitko.

### DIFF
--- a/scripts/votr_export.py
+++ b/scripts/votr_export.py
@@ -146,7 +146,7 @@ def export_predmet_katedra(args):
     app.d.zobrazitPredmetyButton.click()
 
     with app.collect_operations() as ops:
-        app.d.exportButton.click()
+        app.d.printButton.click()
     with app.collect_operations() as ops2:
         app.awaited_abort_box(ops)
     with app.collect_operations() as ops3:


### PR DESCRIPTION
Zjavne sa v AISe opat menilo, co ktore tlacitko robi. Pokazil sa kvoli
tomu export predmetov-katedier: doteraz sa pouzivalo
exportovacie tlacitko, ktore malo vracat .xls, ale realne to bolo len
zamaskovane html.

To sa vsak zmenilo a po novom na toto tlacitko vracia AIS naozaj nejake
xlxs. Nastastie hned vedlajsie tlaciace tlacitko vyzera, ze vracia
to spravne html, ktore potrebujeme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/anketa/227)
<!-- Reviewable:end -->
