### PR TITLE
Fixed problem with uniqueness of short codes #223

### DIFF
--- a/src/AnketaBundle/Lib/SubjectIdentification.php
+++ b/src/AnketaBundle/Lib/SubjectIdentification.php
@@ -73,7 +73,7 @@ class SubjectIdentification implements SubjectIdentificationInterface
     private function getShortCode($longCode)
     {
         $matches = array();
-        if (preg_match('@/(.*)@', $longCode, $matches) !== 1) {
+        if (preg_match('@^[^/]*/(.*)$@', $longCode, $matches) !== 1) {
             // Nevieme zistit kratky kod
             return $longCode;
         }

--- a/src/AnketaBundle/Lib/SubjectIdentification.php
+++ b/src/AnketaBundle/Lib/SubjectIdentification.php
@@ -73,7 +73,7 @@ class SubjectIdentification implements SubjectIdentificationInterface
     private function getShortCode($longCode)
     {
         $matches = array();
-        if (preg_match('@^[^/]*/([^/]+)@', $longCode, $matches) !== 1) {
+        if (preg_match('@/(.*)@', $longCode, $matches) !== 1) {
             // Nevieme zistit kratky kod
             return $longCode;
         }


### PR DESCRIPTION
* Shortening of a subjects code now leaves the numbers after second "/"
because old short codes were no longer unique as mentioned in issue #223

* With this change we loose ability to look at history of a subjects

Signed-off-by: Ondrej Jariabka <o.jariabka@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/anketa/230)
<!-- Reviewable:end -->
