### PR TITLE
Added ability to expand one subject into multiple

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -90,6 +90,7 @@ services:
             - %org_unit%
             - %check_voters_org_unit%
             - "@logger"
+            - %expand_subjects%
     anketa.ldap_retriever:
         class: AnketaBundle\Integration\LDAPRetriever
         arguments:

--- a/src/AnketaBundle/Integration/AISRetriever.php
+++ b/src/AnketaBundle/Integration/AISRetriever.php
@@ -26,10 +26,11 @@ class AISRetriever
         $this->loginInfo = $loginInfo;
     }
 
-    public function getResult($fakulta = null, array $semestre = null) {
+    public function getResult($fakulta = null, array $semestre = null, $expend_subjects = null) {
         $input = $this->getConnectionData();
         $input['fakulta'] = $fakulta;
         $input['semestre'] = $semestre;
+        $input['expand_subjects'] = $expend_subjects;
 
         return $this->runVotr($input);
     }

--- a/src/AnketaBundle/Integration/AISRetriever.php
+++ b/src/AnketaBundle/Integration/AISRetriever.php
@@ -26,11 +26,11 @@ class AISRetriever
         $this->loginInfo = $loginInfo;
     }
 
-    public function getResult($fakulta = null, array $semestre = null, $expend_subjects = null) {
+    public function getResult($fakulta = null, array $semestre = null, $expand_subjects = null) {
         $input = $this->getConnectionData();
         $input['fakulta'] = $fakulta;
         $input['semestre'] = $semestre;
-        $input['expand_subjects'] = $expend_subjects;
+        $input['expand_subjects'] = $expand_subjects;
 
         return $this->runVotr($input);
     }

--- a/src/AnketaBundle/Integration/votr_runner.py
+++ b/src/AnketaBundle/Integration/votr_runner.py
@@ -62,8 +62,8 @@ def main():
                                 rokStudia=zapisny_list.rocnik,
                                 studijnyProgram=dict(skratka=studium.sp_skratka,
                                                      nazov=studium.sp_popis),
-                                expanded_from_vals=dict(skratka=predmet.skratka,
-                                                        nazov=predmet.nazov)
+                                expanded_from=dict(skratka=predmet.skratka,
+                                                   nazov=predmet.nazov)
                             ))
                     else:
                         subjects.append(dict(
@@ -74,7 +74,7 @@ def main():
                             rokStudia=zapisny_list.rocnik,
                             studijnyProgram=dict(skratka=studium.sp_skratka,
                                                  nazov=studium.sp_popis),
-                            expanded_from_vals=None
+                            expanded_from=None
                         ))
 
     client.logout()

--- a/src/AnketaBundle/Integration/votr_runner.py
+++ b/src/AnketaBundle/Integration/votr_runner.py
@@ -17,37 +17,70 @@ def main():
     json_input = json.load(sys.stdin)
     fakulta = json_input['fakulta']
     semestre = json_input['semestre']
+    expand_subjects = json_input['expand_subjects']
     relevantne_roky = [ak_rok for ak_rok, sem in semestre]
 
     client = create_client(json_input['server'], json_input['params'])
 
-#    full_name = client.get_full_name()   # TODO
+    # TODO: full_name = client.get_full_name()
     is_student = False
     subjects = []
 
     if client.get_som_student():
         studia = client.get_studia()
         for studium in studia:
-            if studium.sp_skratka == 'ZEkP' and not studium.organizacna_jednotka: studium = studium._replace(organizacna_jednotka='PriF')
-            if fakulta and studium.organizacna_jednotka != fakulta: continue   # TODO: pouzivat zapisny_list.organizacna_jednotka, ked bude v REST API
+            if (studium.sp_skratka == 'ZEkP' and
+                not studium.organizacna_jednotka):
+                studium = studium._replace(organizacna_jednotka='PriF')
+            # TODO: pouzivat zapisny_list.organizacna_jednotka,
+            # ked bude v REST API
+            if fakulta and studium.organizacna_jednotka != fakulta:
+                continue
+
             for zapisny_list in client.get_zapisne_listy(studium.studium_key):
-                if zapisny_list.akademicky_rok not in relevantne_roky: continue
+                if zapisny_list.akademicky_rok not in relevantne_roky:
+                    continue
                 is_student = True
-                for predmet in client.get_hodnotenia(zapisny_list.zapisny_list_key)[0]:
-                    if [zapisny_list.akademicky_rok, predmet.semester] not in semestre: continue
-                    subjects.append(dict(
-                        skratka=predmet.skratka,
-                        nazov=predmet.nazov,
-                        semester=predmet.semester,
-                        akRok=zapisny_list.akademicky_rok,
-                        rokStudia=zapisny_list.rocnik,
-                        studijnyProgram=dict(skratka=studium.sp_skratka, nazov=studium.sp_popis),
-                    ))
+                zapisny_list_key = zapisny_list.zapisny_list_key
+                for predmet in client.get_hodnotenia(zapisny_list_key)[0]:
+                    subj_time_id = [zapisny_list.akademicky_rok,
+                                    predmet.semester]
+                    if subj_time_id not in semestre:
+                        continue
+
+                    # Ak je to jeden z predmetov, ktore su zadefinovane v
+                    # config_local.yml, ktore treba rozvinut do viacerych
+                    # predmetov ako napriklad chirurgia
+                    if predmet.skratka in expand_subjects:
+                        expanded_predmet = expand_subjects[predmet.skratka]
+                        for expanded in expanded_predmet:
+                            subjects.append(dict(
+                                skratka=expanded['skratka'],
+                                nazov=expanded['nazov'],
+                                semester=predmet.semester,
+                                akRok=zapisny_list.akademicky_rok,
+                                rokStudia=zapisny_list.rocnik,
+                                studijnyProgram=dict(skratka=studium.sp_skratka,
+                                                     nazov=studium.sp_popis),
+                                expanded_from_vals=dict(skratka=predmet.skratka,
+                                                        nazov=predmet.nazov)
+                            ))
+                    else:
+                        subjects.append(dict(
+                            skratka=predmet.skratka,
+                            nazov=predmet.nazov,
+                            semester=predmet.semester,
+                            akRok=zapisny_list.akademicky_rok,
+                            rokStudia=zapisny_list.rocnik,
+                            studijnyProgram=dict(skratka=studium.sp_skratka,
+                                                 nazov=studium.sp_popis),
+                            expanded_from_vals=None
+                        ))
 
     client.logout()
 
     result = {}
-#    result['full_name'] = full_name
+    # result['full_name'] = full_name
     result['is_student'] = is_student
     result['subjects'] = subjects
 

--- a/src/AnketaBundle/Security/AISUserSource.php
+++ b/src/AnketaBundle/Security/AISUserSource.php
@@ -51,7 +51,7 @@ class AISUserSource implements UserSourceInterface
 
     public function __construct(Connection $dbConn, EntityManager $em, AISRetriever $aisRetriever,
             SubjectIdentificationInterface $subjectIdentification, $allowedOrgUnit, $checkOrgUnit,
-            LoggerInterface $logger = null, $expand_subjects)
+            LoggerInterface $logger = null, $expand_subjects = null)
     {
         $this->dbConn = $dbConn;
         $this->em = $em;
@@ -105,7 +105,7 @@ class AISUserSource implements UserSourceInterface
 
         foreach ($aisPredmety as $aisPredmet) {
             $props = $this->subjectIdentification->identify($aisPredmet['skratka'], $aisPredmet['nazov']);
-            $expanded_from = $aisPredmet['expanded_from_vals'];
+            $expanded_from = $aisPredmet['expanded_from'];
 
             // Ignorujme duplicitne predmety
             if (in_array($props['slug'], $slugy)) {

--- a/src/AnketaBundle/Security/AISUserSource.php
+++ b/src/AnketaBundle/Security/AISUserSource.php
@@ -46,9 +46,12 @@ class AISUserSource implements UserSourceInterface
     /** @var string */
     private $allowedOrgUnit;
 
+    /** @var array */
+    private $expand_subjects;
+
     public function __construct(Connection $dbConn, EntityManager $em, AISRetriever $aisRetriever,
             SubjectIdentificationInterface $subjectIdentification, $allowedOrgUnit, $checkOrgUnit,
-            LoggerInterface $logger = null)
+            LoggerInterface $logger = null, $expand_subjects)
     {
         $this->dbConn = $dbConn;
         $this->em = $em;
@@ -56,6 +59,7 @@ class AISUserSource implements UserSourceInterface
         $this->logger = $logger;
         $this->subjectIdentification = $subjectIdentification;
         $this->allowedOrgUnit = ($checkOrgUnit ? $allowedOrgUnit : null);
+        $this->expand_subjects = $expand_subjects;
     }
 
     public function load(UserSeason $userSeason, array $want)
@@ -73,7 +77,7 @@ class AISUserSource implements UserSourceInterface
                 }
             }
 
-            $result = $this->aisRetriever->getResult($this->allowedOrgUnit, $semestre);
+            $result = $this->aisRetriever->getResult($this->allowedOrgUnit, $semestre, $this->expand_subjects);
 
             if ($result['is_student']) {
                 if (isset($want['subjects'])) {
@@ -101,6 +105,7 @@ class AISUserSource implements UserSourceInterface
 
         foreach ($aisPredmety as $aisPredmet) {
             $props = $this->subjectIdentification->identify($aisPredmet['skratka'], $aisPredmet['nazov']);
+            $expanded_from = $aisPredmet['expanded_from_vals'];
 
             // Ignorujme duplicitne predmety
             if (in_array($props['slug'], $slugy)) {
@@ -156,6 +161,20 @@ class AISUserSource implements UserSourceInterface
                 throw new \Exception("Nepodarilo sa pridať väzbu študent-predmet do DB");
             }
             $stmt = null;
+
+            if ($expanded_from != null) {
+                $old_props = $this->subjectIdentification->identify($expanded_from['skratka'], $expanded_from['nazov']);
+                $stmt = $this->dbConn->prepare("INSERT INTO TeachersSubjects(teacher_id, subject_id, season_id, lecturer, trainer)
+                                                SELECT teacher_id, s2.id as subject_id, season_id, lecturer, trainer from TeachersSubjects as ts, Subject as s, Subject as s2
+                                                WHERE s.id = ts.subject_id and s.code=:old_code and s2.code=:new_code
+                                                ON DUPLICATE KEY UPDATE subject_id=s2.id");
+                $stmt->bindValue('old_code', $old_props['code']);
+                $stmt->bindValue('new_code', $props['code']);
+                if (!$stmt->execute()) {
+                    throw new \Exception("Nepodarilo sa získať učiteľa pôvodného AIS predmetu");
+                }
+                $stmt = null;
+            }
 
             $this->dbConn->commit();
         }


### PR DESCRIPTION
* Added new value `expand_subjects` to `config.yml` into anketa.ais_user_source
which should specify subjects (based on their long code) that should be split
into multiple subjects and is defined in `config_local.yml`.
Each entry should contain new long code for the subject as well as new name of
the subject.

* In votr_runner.py we check if the subject is in list `expand_subjects`
and if so we multiply it based on this array defined in `config_local.yml`
If the subject was expanded we also add to subjects structure a value containing
its "old" name and code. This value is None if it is a normal subject.

* `AISRetriver` just obtains this new value passed from `AISUserSource` and
sends it into `runVotr()` function where this value is passed to `votr_runner.py`

* AISUserSource recieves this value from from `config.yml` passes it first to
`AISRetriver` and then if the results are concerning student it loads all
necessary subjects including the new ones added in `votr_runner.py`. These new
subjects are first added to all "Subject" tables and then Teacher-New_Subject
pairs are added to `TeachersSubjects` tables based on the "old" name and code
values send from `votr_runner` with expanded subjects.

* Should close #236 

Signed-off-by: Ondrej Jariabka <o.jariabka@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/anketa/237)
<!-- Reviewable:end -->
