### PR TITLE
Fix: Fixed sorting of results by subject in anketa

### DIFF
--- a/src/AnketaBundle/Entity/Subject.php
+++ b/src/AnketaBundle/Entity/Subject.php
@@ -80,11 +80,13 @@ class Subject {
     public function getCategory()
     {
         $matches = array();
-        $stred = preg_match('@^[^/]*/(.*)$@', $this->getCode(), $matches);
+        $stred = preg_match('@^[^/]*/([^/]*)/.*$@', $this->getCode(), $matches);
         if ($stred == 0) {
+            // Ide o kratky kod typu 1-XXX-NNN/nn
             $zvysok = $this->getCode();
         }
         else {
+            // Ide o dlhy kod typu FMFI-PriF.XXXX/1-XXX-NNN/nn
             $zvysok = $matches[1];
         }
         $matches = array();


### PR DESCRIPTION
* All results in `Vysledky -> Predmety` are now sorted properly. Before results
were not matching the 'new' longer code and all ended up as uncategorized.

* Should close #106 

Signed-off-by: Ondrej Jariabka <o.jariabka@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/anketa/238)
<!-- Reviewable:end -->
