### PR TITLE
fix: Move deprecated Google Charts API to Image Charts

### DIFF
--- a/src/AnketaBundle/Controller/StatisticsController.php
+++ b/src/AnketaBundle/Controller/StatisticsController.php
@@ -156,7 +156,7 @@ class StatisticsController extends Controller {
         );
 
         $url = (isset($_SERVER['HTTPS']) ? 'https' : 'http') .
-            '://chart.googleapis.com/chart?' . http_build_query($options);
+            '://image-charts.com/chart?' . http_build_query($options);
 
         return array('url' => $url, 'width' => $width, 'height' => $height);
     }


### PR DESCRIPTION
* The Google Charts API has been deprecated for a whie https://developers.google.com/chart/image/docs/making_charts

* We thus use a 1:1 replacement (albeit with some ads: https://stackoverflow.com/questions/16003624/google-chart-images-replacement)

Signed-off-by: mr.Shu <mr@shu.io>

k

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/anketa/259)
<!-- Reviewable:end -->
