### PR TITLE
fix reports error when user has no department

### DIFF
--- a/src/AnketaBundle/Controller/ReportsController.php
+++ b/src/AnketaBundle/Controller/ReportsController.php
@@ -109,6 +109,7 @@ class ReportsController extends Controller {
 
         $items = array();
         $authorized_people = array();
+        $authorized_people_no_department = array();
 
         $departments = $access->getDepartmentReports($season);
         $departmentRepository = $em->getRepository('AnketaBundle:Department');
@@ -129,6 +130,8 @@ class ReportsController extends Controller {
                 $depart = $userRepository->getUserDepartment($user, $season);
                 if ($depart !== null)
                     $authorized_people[$depart->getName()][] = $user;
+                else
+                    $authorized_people_no_department[] = $user;
             }
         }
 
@@ -157,11 +160,14 @@ class ReportsController extends Controller {
         $templateParams = array();
         $templateParams['authorizedPeopleToggleButton'] = $this->get('translator')->trans('reports.controller.opravnene_osoby_button');
         $templateParams['authorizedPeopleTitle'] = $this->get('translator')->trans('reports.controller.opravnene_osoby_nadpis');
+        $templateParams['authorizedPeopleNoDepartmentTitle'] = $this->get('translator')->trans('reports.controller.opravnene_osoby_bez_departmentu_nadpis');
         $templateParams['title'] = $this->get('translator')->trans('reports.controller.moje_reporty');
         $templateParams['activeMenuItems'] = array($season->getId(), 'my_reports');
         $templateParams['items'] = $items;
-        if($access->hasAllReports())
+        if($access->hasAllReports()) {
             $templateParams['authorized_people'] = $authorized_people;
+            $templateParams['authorized_people_no_department'] = $authorized_people_no_department;
+        }
         return $this->render('AnketaBundle:Statistics:listing.html.twig', $templateParams);
     }
 }

--- a/src/AnketaBundle/Controller/ReportsController.php
+++ b/src/AnketaBundle/Controller/ReportsController.php
@@ -127,7 +127,8 @@ class ReportsController extends Controller {
             $users = $userRepository->findUsersWithAnyRole(array('ROLE_DEPARTMENT_REPORT'));
             foreach($users as $user){
                 $depart = $userRepository->getUserDepartment($user, $season);
-                $authorized_people[$depart->getName()][] = $user;
+                if ($depart !== null)
+                    $authorized_people[$depart->getName()][] = $user;
             }
         }
 

--- a/src/AnketaBundle/Entity/UserRepository.php
+++ b/src/AnketaBundle/Entity/UserRepository.php
@@ -291,9 +291,9 @@ class UserRepository extends EntityRepository {
                    ->setParameter('season', $season)
                    ->setParameter('user', $user)
                    ->getOneOrNullResult();
+
         if($department === null) {
-            $department = $user->getDepartment();
-            if ($department === null) throw new \Exception("User ".$user->getLogin()." nema department");
+            $department = $user->getDepartment();  // this might be also NULL
         }
         return $department;
     }

--- a/src/AnketaBundle/Resources/public/css/main.css
+++ b/src/AnketaBundle/Resources/public/css/main.css
@@ -32,8 +32,12 @@ ul.authorized_people li:last-child:after {
  content: "";
 }
 
-#authorized_people_title {
+#authorized_people_title, #authorized_people_no_department_title {
   display: none;
+}
+
+#authorized_people_no_department_title {
+  margin-top: 10px;
 }
 
 ul.authorized_people  li {

--- a/src/AnketaBundle/Resources/public/js/reports.js
+++ b/src/AnketaBundle/Resources/public/js/reports.js
@@ -1,4 +1,5 @@
 $('#authorized_people_checkbox').click(function() {
     $('#authorized_people_title').toggle();
+    $('#authorized_people_no_department_title').toggle();
     $('.authorized_people_hidden').toggleClass('authorized_people');
 });

--- a/src/AnketaBundle/Resources/translations/messages.en.yml
+++ b/src/AnketaBundle/Resources/translations/messages.en.yml
@@ -184,6 +184,7 @@ reports:
     opravnene_osoby: Authorized persons
     opravnene_osoby_button: Who see reports?
     opravnene_osoby_nadpis: People who see all reports:
+    opravnene_osoby_bez_departmentu_nadpis: People, who are not assigned to department:
 
 response:
   delete:

--- a/src/AnketaBundle/Resources/translations/messages.sk.yml
+++ b/src/AnketaBundle/Resources/translations/messages.sk.yml
@@ -186,6 +186,7 @@ reports:
     opravnene_osoby: Autorizované osoby
     opravnene_osoby_button: Kto vidí reporty?
     opravnene_osoby_nadpis: Ľudia, ktorí vidia všetky reporty:
+    opravnene_osoby_bez_departmentu_nadpis: Ľudia, ktorí nemajú katedru:
 
 response:
   delete:

--- a/src/AnketaBundle/Resources/views/Statistics/listing.html.twig
+++ b/src/AnketaBundle/Resources/views/Statistics/listing.html.twig
@@ -12,13 +12,19 @@
         <input type="button" name="authorized_people" id="authorized_people_checkbox" value="{{ authorizedPeopleToggleButton }}"/>
         <h3 id="authorized_people_title">{{ authorizedPeopleTitle }}</h3>
         <ul class="authorized_people_hidden">
-        {% for person in authorized_people['ROLE_ALL_REPORTS'] %}
-            {% if not loop.last %}
-                <li>{{ person }}</li>
-            {% else %}
-                <li>{{ person }}</li>
-            {% endif %}
-        {% endfor %}</ul>
+          {% for person in authorized_people['ROLE_ALL_REPORTS'] %}
+              <li>{{ person }}</li>
+          {% endfor %}
+        </ul>
+
+        {% if authorized_people_no_department is defined %}
+            <h4 id="authorized_people_no_department_title">{{ authorizedPeopleNoDepartmentTitle }}</h4>
+            <ul class="authorized_people_hidden">
+                {% for person in authorized_people_no_department %}
+                    <li>{{ person }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
     {% endif %}
     {% for category_title, list in items %}
         {% if category_title is not empty %}

--- a/src/AnketaBundle/Resources/views/Statistics/listing.html.twig
+++ b/src/AnketaBundle/Resources/views/Statistics/listing.html.twig
@@ -27,7 +27,7 @@
         <ul class="category-listing {{ class|default('') }}">
             {% for item_text, item_href in list %}
                 <li><a href="{{ item_href }}">{{ item_text }}</a>
-                {% if authorized_people is defined %}<ul class="authorized_people_hidden">
+                {% if authorized_people is defined and item_text in authorized_people|keys %}<ul class="authorized_people_hidden">
                     {% for person in authorized_people[item_text] %}
                         {% if not loop.last %}
                             <li>{{ person }}</li>


### PR DESCRIPTION
* If a user had i.e. department reports role assigned
  and no department assigned at the same time, the app
  crashed with error. This fix just skips such users.
* fixes #285

Signed-off-by: Adrian Matejov <ado.matejov@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/anketa/286)
<!-- Reviewable:end -->
