### PR TITLE
OS upgrady

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,16 @@
-FROM php:5.5-apache AS base
+FROM php:7.2-apache AS base
 COPY --from=composer/composer:2.2-bin /composer /usr/local/bin/
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 # For some reason the image does not come with php.ini, so it defaults to log_errors=Off. :C
-ADD https://github.com/php/php-src/raw/refs/heads/PHP-5.5/php.ini-production /usr/local/etc/php/php.ini
+ADD https://github.com/php/php-src/raw/refs/heads/PHP-7.2/php.ini-production /usr/local/etc/php/php.ini
 RUN <<EOF
     set -e
-    # jessie is too old and the default sources.list doesn't work.
-    echo '
-        deb http://archive.debian.org/debian/ jessie main
-        deb-src http://archive.debian.org/debian/ jessie main
-        deb http://archive.debian.org/debian-security/ jessie/updates main
-        deb-src http://archive.debian.org/debian-security/ jessie/updates main
-    ' > /etc/apt/sources.list
     # unzip and git are needed by composer.
     # libldap2-dev is needed by PHP ldap, installed below.
     # locales is needed for locale-gen below.
-    # ca-certificates needs to be updated for connections to repo.packagist.org (it uses Let's Encrypt).
+    # acl is needed by scripts/init_all.sh for setfacl.
     apt-get update --allow-unauthenticated
-    apt-get install -y --no-install-recommends --allow-unauthenticated unzip git libldap2-dev locales ca-certificates
+    apt-get install -y --no-install-recommends --allow-unauthenticated unzip git libldap2-dev locales acl
     rm -rf /var/lib/apt/lists/*
     # For some reason the image does not come with ldap and pdo_mysql. This compiles them from source. :C
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/

--- a/app/config/config_local.yml.dist
+++ b/app/config/config_local.yml.dist
@@ -13,7 +13,7 @@ parameters:
 #        dbname:   anketa
 #        user:     anketa
 #        password: ~
-#        charset:  UTF8
+#        charset:  utf8mb4
 
     allow_db_reset: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,10 @@ services:
       - db
 
   db:
-    image: mysql:5.5
-    # utf8mb4 would be better. This is for bug-for-bug consistency with svt4.
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+    # Hack: `-debian` because `mysql:8.0` uses oraclelinux 9, which requires x86-64-v2, but omega.svt cpu is too old.
+    image: mysql:8.0-debian
+    # The default plugin (caching_sha2_password) doesn't work with PHP < 7.4.
+    command: mysqld --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: anketa


### PR DESCRIPTION
V tomto PR testujem veľké upgrady systémových závislostí (PHP a MySQL) aby sme sa pripravili na Ubuntu OS upgrade.

Vyzerá že všetko funguje, ale najlepšie by bolo mergnuť až vtedy keď spravíme ten OS upgrade, aby Dockerfile zhruba vždy zodpovedal produkcii.

PHP 7.2 nie je najnovšia verzia ale už sa aspoň nachádza v Surého PPA, na rozdiel od nášho starého 5.5.

Čo sa týka MySQL 8.0: Za prvé zmenili niečo s prihlasovaním, čo nefunguje s PHP<7.4 takže to treba nastaviť po starom. Za druhé už defaultné kódovanie je utf8mb4 a netreba sa s tým toľko otravovať, takže môžeme zrušiť náš custom kódovanie config. Ale naša databáza je utf8 a.k.a. utf8mb3. Možno sa to dá alternúť aj za behu, ale ja som to skonvertoval pri načítaní z dumpu takýmto príkazom.

```sh
xzcat -v /tmp/latest-anonymous.sql.xz | sed -r '/^\)/ s/DEFAULT CHARSET.*/DEFAULT CHARSET=utf8mb4;/ ; /^-- Final view/,$ { s/utf8\b/utf8mb4/; s/utf8_\w+/utf8mb4_0900_ai_ci/ }' | docker compose exec -T db mysql -uanketa -panketa anketa
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/anketa/298)
<!-- Reviewable:end -->
